### PR TITLE
Travis CI for automated testing of all submissions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,27 @@
+group: travis_latest
+language: python
+cache: pip
+python:
+    - 2.7
+    - 3.6
+    #- nightly
+    #- pypy
+    #- pypy3
+matrix:
+    allow_failures:
+        - python: nightly
+        - python: pypy
+        - python: pypy3
+install:
+    #- pip install -r requirements.txt
+    - pip install flake8  # pytest  # add another testing frameworks later
+before_script:
+    # stop the build if there are Python syntax errors or undefined names
+    - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+    # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
+    - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+script:
+    - true  # pytest --capture=sys  # add other tests here
+notifications:
+    on_success: change
+    on_failure: change  # `always` will be the setting once code changes slow down

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,10 @@ cache: pip
 python:
     - 3.6
     #- nightly
-    #- pypy
     #- pypy3
 matrix:
     allow_failures:
         - python: nightly
-        - python: pypy
         - python: pypy3
 install:
     #- pip install -r requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ group: travis_latest
 language: python
 cache: pip
 python:
-    - 2.7
     - 3.6
     #- nightly
     #- pypy


### PR DESCRIPTION
Travis Continuous Integration service can run automated testing using [flake8](http://flake8.pycqa.org) on all pull requests.  Travis CI is free for all open source projects like this one and to turn it on, visit https://travis-ci.com/profile  This config file will have Travis CI run flake8 tests to find Python syntax errors and undefined names in all pull requests before they are reviewed.