### PR TITLE
Fix compiling errors for pytorch 0.4.1

### DIFF
--- a/lib/model/nms/src/nms_cuda.c
+++ b/lib/model/nms/src/nms_cuda.c
@@ -8,12 +8,12 @@ extern THCState *state;
 int nms_cuda(THCudaIntTensor *keep_out, THCudaTensor *boxes_host,
 		     THCudaIntTensor *num_out, float nms_overlap_thresh) {
 
-	nms_cuda_compute(THCudaIntTensor_data(state, keep_out), 
-		         THCudaIntTensor_data(state, num_out), 
-      	                 THCudaTensor_data(state, boxes_host), 
-		         boxes_host->size[0], 
-		         boxes_host->size[1],
-		         nms_overlap_thresh);
+    nms_cuda_compute(THCudaIntTensor_data(state, keep_out),
+                     THCudaIntTensor_data(state, num_out),
+                     THCudaTensor_data(state, boxes_host),
+                     THCudaTensor_size(state, boxes_host, 0),
+                     THCudaTensor_size(state, boxes_host, 1),
+                     nms_overlap_thresh);
 
 	return 1;
 }

--- a/lib/model/roi_crop/make.sh
+++ b/lib/model/roi_crop/make.sh
@@ -7,4 +7,4 @@ echo "Compiling my_lib kernels by nvcc..."
 nvcc -c -o roi_crop_cuda_kernel.cu.o roi_crop_cuda_kernel.cu -x cu -Xcompiler -fPIC -arch=sm_52
 
 cd ../
-python build.py
+python3 build.py

--- a/lib/model/roi_crop/src/roi_crop.c
+++ b/lib/model/roi_crop/src/roi_crop.c
@@ -7,24 +7,24 @@
 int BilinearSamplerBHWD_updateOutput(THFloatTensor *inputImages, THFloatTensor *grids, THFloatTensor *output)
 {
 
-  int batchsize = inputImages->size[0];
-  int inputImages_height = inputImages->size[1];
-  int inputImages_width = inputImages->size[2];
-  int output_height = output->size[1];
-  int output_width = output->size[2];
-  int inputImages_channels = inputImages->size[3];
+  int batchsize = THFloatTensor_size(inputImages, 0);
+  int inputImages_height = THFloatTensor_size(inputImages, 1);
+  int inputImages_width = THFloatTensor_size(inputImages, 2);
+  int output_height = THFloatTensor_size(output, 1);
+  int output_width = THFloatTensor_size(output, 2);
+  int inputImages_channels = THFloatTensor_size(inputImages, 3);
 
-  int output_strideBatch = output->stride[0];
-  int output_strideHeight = output->stride[1];
-  int output_strideWidth = output->stride[2];
+  int output_strideBatch = THFloatTensor_stride(output, 0);
+  int output_strideHeight = THFloatTensor_stride(output, 1);
+  int output_strideWidth = THFloatTensor_stride(output, 2);
 
-  int inputImages_strideBatch = inputImages->stride[0];
-  int inputImages_strideHeight = inputImages->stride[1];
-  int inputImages_strideWidth = inputImages->stride[2];
+  int inputImages_strideBatch = THFloatTensor_stride(inputImages, 0);
+  int inputImages_strideHeight = THFloatTensor_stride(inputImages, 1);
+  int inputImages_strideWidth = THFloatTensor_stride(inputImages, 2);
 
-  int grids_strideBatch = grids->stride[0];
-  int grids_strideHeight = grids->stride[1];
-  int grids_strideWidth = grids->stride[2];
+  int grids_strideBatch = THFloatTensor_stride(grids, 0);
+  int grids_strideHeight = THFloatTensor_stride(grids, 1);
+  int grids_strideWidth = THFloatTensor_stride(grids, 2);
 
 
   real *inputImages_data, *output_data, *grids_data;
@@ -107,32 +107,32 @@ int BilinearSamplerBHWD_updateGradInput(THFloatTensor *inputImages, THFloatTenso
 {
   bool onlyGrid=false;
 
-  int batchsize = inputImages->size[0];
-  int inputImages_height = inputImages->size[1];
-  int inputImages_width = inputImages->size[2];
-  int gradOutput_height = gradOutput->size[1];
-  int gradOutput_width = gradOutput->size[2];
-  int inputImages_channels = inputImages->size[3];
+  int batchsize = THFloatTensor_size(inputImages, 0);
+  int inputImages_height = THFloatTensor_size(inputImages, 1);
+  int inputImages_width = THFloatTensor_size(inputImages, 2);
+  int gradOutput_height = THFloatTensor_size(gradOutput, 1);
+  int gradOutput_width = THFloatTensor_size(gradOutput, 2);
+  int inputImages_channels = THFloatTensor_size(inputImages, 3);
 
-  int gradOutput_strideBatch = gradOutput->stride[0];
-  int gradOutput_strideHeight = gradOutput->stride[1];
-  int gradOutput_strideWidth = gradOutput->stride[2];
+  int inputImages_strideBatch = THFloatTensor_stride(inputImages, 0);
+  int inputImages_strideHeight = THFloatTensor_stride(inputImages, 1);
+  int inputImages_strideWidth = THFloatTensor_stride(inputImages, 2);
 
-  int inputImages_strideBatch = inputImages->stride[0];
-  int inputImages_strideHeight = inputImages->stride[1];
-  int inputImages_strideWidth = inputImages->stride[2];
+  int gradOutput_strideBatch = THFloatTensor_stride(gradOutput, 0);
+  int gradOutput_strideHeight = THFloatTensor_stride(gradOutput, 1);
+  int gradOutput_strideWidth = THFloatTensor_stride(gradOutput, 2);
 
-  int gradInputImages_strideBatch = gradInputImages->stride[0];
-  int gradInputImages_strideHeight = gradInputImages->stride[1];
-  int gradInputImages_strideWidth = gradInputImages->stride[2];
+  int gradInputImages_strideBatch = THFloatTensor_stride(gradInputImages, 0);
+  int gradInputImages_strideHeight = THFloatTensor_stride(gradInputImages, 1);
+  int gradInputImages_strideWidth = THFloatTensor_stride(gradInputImages, 2);
 
-  int grids_strideBatch = grids->stride[0];
-  int grids_strideHeight = grids->stride[1];
-  int grids_strideWidth = grids->stride[2];
+  int grids_strideBatch = THFloatTensor_stride(grids, 0);
+  int grids_strideHeight = THFloatTensor_stride(grids, 1);
+  int grids_strideWidth = THFloatTensor_stride(grids, 2);
 
-  int gradGrids_strideBatch = gradGrids->stride[0];
-  int gradGrids_strideHeight = gradGrids->stride[1];
-  int gradGrids_strideWidth = gradGrids->stride[2];
+  int gradGrids_strideBatch = THFloatTensor_stride(gradGrids, 0);
+  int gradGrids_strideHeight = THFloatTensor_stride(gradGrids, 1);
+  int gradGrids_strideWidth = THFloatTensor_stride(gradGrids, 2);
 
   real *inputImages_data, *gradOutput_data, *grids_data, *gradGrids_data, *gradInputImages_data;
   inputImages_data = THFloatTensor_data(inputImages);
@@ -246,29 +246,29 @@ int BilinearSamplerBHWD_updateGradInput(THFloatTensor *inputImages, THFloatTenso
 int BilinearSamplerBCHW_updateOutput(THFloatTensor *inputImages, THFloatTensor *grids, THFloatTensor *output)
 {
 
-  int batchsize = inputImages->size[0];
-  int inputImages_height = inputImages->size[2];
-  int inputImages_width = inputImages->size[3];
+  int batchsize = THFloatTensor_size(inputImages, 0);
+  int inputImages_height = THFloatTensor_size(inputImages, 2);
+  int inputImages_width = THFloatTensor_size(inputImages, 3);
   
-  int output_height = output->size[2];
-  int output_width = output->size[3];
-  int inputImages_channels = inputImages->size[1];
+  int output_height = THFloatTensor_size(output, 2);
+  int output_width = THFloatTensor_size(output, 3);
+  int inputImages_channels = THFloatTensor_size(inputImages, 1);
 
-  int output_strideBatch = output->stride[0];
-  int output_strideHeight = output->stride[2];
-  int output_strideWidth = output->stride[3];  
-  int output_strideChannel = output->stride[1];
+  int output_strideBatch = THFloatTensor_stride(output, 0);
+  int output_strideHeight = THFloatTensor_stride(output, 2);
+  int output_strideWidth = THFloatTensor_stride(output, 3);
+  int output_strideChannel = THFloatTensor_stride(output, 1);
     
 
-  int inputImages_strideBatch = inputImages->stride[0];
-  int inputImages_strideHeight = inputImages->stride[2];
-  int inputImages_strideWidth = inputImages->stride[3];
-  int inputImages_strideChannel = inputImages->stride[1];
+  int inputImages_strideBatch = THFloatTensor_stride(inputImages, 0);
+  int inputImages_strideHeight = THFloatTensor_stride(inputImages, 2);
+  int inputImages_strideWidth = THFloatTensor_stride(inputImages, 3);
+  int inputImages_strideChannel = THFloatTensor_stride(inputImages, 1);
 
-  int grids_strideBatch = grids->stride[0];
-  int grids_strideHeight = grids->stride[2];
-  int grids_strideWidth = grids->stride[3];
-  int grids_strideChannel = grids->stride[1];
+  int grids_strideBatch = THFloatTensor_stride(grids, 0);
+  int grids_strideHeight = THFloatTensor_stride(grids, 2);
+  int grids_strideWidth = THFloatTensor_stride(grids, 3);
+  int grids_strideChannel = THFloatTensor_stride(grids, 1);
 
 
   real *inputImages_data, *output_data, *grids_data;
@@ -352,38 +352,37 @@ int BilinearSamplerBCHW_updateGradInput(THFloatTensor *inputImages, THFloatTenso
 {
   bool onlyGrid=false;
 
-  int batchsize = inputImages->size[0];
-  int inputImages_height = inputImages->size[2];
-  int inputImages_width = inputImages->size[3];
-  int gradOutput_height = gradOutput->size[2];
-  int gradOutput_width = gradOutput->size[3];
-  int inputImages_channels = inputImages->size[1];
+  int batchsize = THFloatTensor_size(inputImages, 0);
+  int inputImages_height = THFloatTensor_size(inputImages, 2);
+  int inputImages_width = THFloatTensor_size(inputImages, 3);
+  int inputImages_channels = THFloatTensor_size(inputImages, 1);
+  int gradOutput_height = THFloatTensor_size(gradOutput, 2);
+  int gradOutput_width = THFloatTensor_size(gradOutput, 3);
 
-  int gradOutput_strideBatch = gradOutput->stride[0];
-  int gradOutput_strideHeight = gradOutput->stride[2];
-  int gradOutput_strideWidth = gradOutput->stride[3];
-  int gradOutput_strideChannel = gradOutput->stride[1];
+  int gradOutput_strideBatch = THFloatTensor_stride(gradOutput, 0);
+  int gradOutput_strideHeight = THFloatTensor_stride(gradOutput, 2);
+  int gradOutput_strideWidth = THFloatTensor_stride(gradOutput, 3);
+  int gradOutput_strideChannel = THFloatTensor_stride(gradOutput, 1);
 
-  int inputImages_strideBatch = inputImages->stride[0];
-  int inputImages_strideHeight = inputImages->stride[2];
-  int inputImages_strideWidth = inputImages->stride[3];
-  int inputImages_strideChannel = inputImages->stride[1];
-    
+  int inputImages_strideBatch = THFloatTensor_stride(inputImages, 0);
+  int inputImages_strideHeight = THFloatTensor_stride(inputImages, 2);
+  int inputImages_strideWidth = THFloatTensor_stride(inputImages, 3);
+  int inputImages_strideChannel = THFloatTensor_stride(inputImages, 1);
 
-  int gradInputImages_strideBatch = gradInputImages->stride[0];
-  int gradInputImages_strideHeight = gradInputImages->stride[2];
-  int gradInputImages_strideWidth = gradInputImages->stride[3];
-  int gradInputImages_strideChannel = gradInputImages->stride[1];
+  int gradInputImages_strideBatch = THFloatTensor_stride(gradInputImages, 0);
+  int gradInputImages_strideHeight = THFloatTensor_stride(gradInputImages, 2);
+  int gradInputImages_strideWidth = THFloatTensor_stride(gradInputImages, 3);
+  int gradInputImages_strideChannel = THFloatTensor_stride(gradInputImages, 1);
 
-  int grids_strideBatch = grids->stride[0];
-  int grids_strideHeight = grids->stride[2];
-  int grids_strideWidth = grids->stride[3];
-  int grids_strideChannel = grids->stride[1];
+  int grids_strideBatch = THFloatTensor_stride(grids, 0);
+  int grids_strideHeight = THFloatTensor_stride(grids, 2);
+  int grids_strideWidth = THFloatTensor_stride(grids, 3);
+  int grids_strideChannel = THFloatTensor_stride(grids, 1);
 
-  int gradGrids_strideBatch = gradGrids->stride[0];
-  int gradGrids_strideHeight = gradGrids->stride[2];
-  int gradGrids_strideWidth = gradGrids->stride[3];
-  int gradGrids_strideChannel = gradGrids->stride[1];
+  int gradGrids_strideBatch = THFloatTensor_stride(gradGrids, 0);
+  int gradGrids_strideHeight = THFloatTensor_stride(gradGrids, 2);
+  int gradGrids_strideWidth = THFloatTensor_stride(gradGrids, 3);
+  int gradGrids_strideChannel = THFloatTensor_stride(gradGrids, 1);
 
   real *inputImages_data, *gradOutput_data, *grids_data, *gradGrids_data, *gradInputImages_data;
   inputImages_data = THFloatTensor_data(inputImages);

--- a/lib/model/roi_crop/src/roi_crop_cuda.c
+++ b/lib/model/roi_crop/src/roi_crop_cuda.c
@@ -19,10 +19,10 @@ int BilinearSamplerBHWD_updateOutput_cuda(THCudaTensor *inputImages, THCudaTenso
 //  THCudaTensor *output = (THCudaTensor *)luaT_checkudata(L, 4, "torch.CudaTensor");
 
   int success = 0;
-  success = BilinearSamplerBHWD_updateOutput_cuda_kernel(output->size[1],
-                                               output->size[3],
-                                               output->size[2],
-                                               output->size[0],
+  success = BilinearSamplerBHWD_updateOutput_cuda_kernel(THCudaTensor_size(state, output, 1),
+                                               THCudaTensor_size(state, output, 3),
+                                               THCudaTensor_size(state, output, 2),
+                                               THCudaTensor_size(state, output, 0),
                                                THCudaTensor_size(state, inputImages, 1),
                                                THCudaTensor_size(state, inputImages, 2),
                                                THCudaTensor_size(state, inputImages, 3),
@@ -62,10 +62,10 @@ int BilinearSamplerBHWD_updateGradInput_cuda(THCudaTensor *inputImages, THCudaTe
 //  THCudaTensor *gradOutput = (THCudaTensor *)luaT_checkudata(L, 6, "torch.CudaTensor");
 
   int success = 0;
-  success = BilinearSamplerBHWD_updateGradInput_cuda_kernel(gradOutput->size[1],
-                                                  gradOutput->size[3],
-                                                  gradOutput->size[2],
-                                                  gradOutput->size[0],
+  success = BilinearSamplerBHWD_updateGradInput_cuda_kernel(THCudaTensor_size(state, gradOutput, 1),
+                                                  THCudaTensor_size(state, gradOutput, 3),
+                                                  THCudaTensor_size(state, gradOutput, 2),
+                                                  THCudaTensor_size(state, gradOutput, 0),
                                                   THCudaTensor_size(state, inputImages, 1),
                                                   THCudaTensor_size(state, inputImages, 2),
                                                   THCudaTensor_size(state, inputImages, 3),


### PR DESCRIPTION
Fix compiling errors of nms, roi_crop modules:
`*->size ...` -> THCudaTensor_size(state, *`  and similar
